### PR TITLE
Add CODEOWNERS file for approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners are Networking WG leads and TOC
+* @knative-sandbox/technical-oversight-committee
+* @knative-sandbox/knative-release-leads
+* @knative-sandbox/networking-wg-leads
+# Last match takes precedence for reviews
+* @knative-sandbox/net-certmanager-approvers
+
+# hack and test are owned by productivity
+/hack/* @knative-sandbox/productivity-wg-leads
+/test/* @knative-sandbox/productivity-wg-leads


### PR DESCRIPTION
Needs https://github.com/knative/community/pull/479 to land for net-certmanager-approvers to work.