### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,7 +47,7 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative net-certmanager - ${config}"
-    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -33,7 +33,7 @@ function upload_test_images() {
       sed "s@ko://@ko://knative.dev/net-certmanager/vendor/@g" $yaml \
         `# ko resolve is being used for the side-effect of publishing images,` \
         `# so the resulting yaml produced is ignored.` \
-        | ko resolve --strict ${tag_option} -RBf- > /dev/null
+        | ko resolve ${tag_option} -RBf- > /dev/null
     done
   )
 }


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

/assign @nak3