### PR TITLE
Add k8s recommended labels

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -18,6 +18,9 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -18,9 +18,9 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -17,6 +17,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 webhooks:

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -17,9 +17,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 webhooks:

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -18,8 +18,8 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -18,5 +18,8 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,9 +18,9 @@ metadata:
   name: net-certmanager-controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
@@ -33,9 +33,9 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: net-certmanager-controller
-        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/component: net-certmanager
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/name: knative-serving
         serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
@@ -87,9 +87,9 @@ kind: Service
 metadata:
   labels:
     app: net-certmanager-controller
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
   name: net-certmanager-controller

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,6 +18,9 @@ metadata:
   name: net-certmanager-controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
@@ -30,6 +33,9 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: net-certmanager-controller
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: knative-serving
         serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
@@ -81,6 +87,9 @@ kind: Service
 metadata:
   labels:
     app: net-certmanager-controller
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
   name: net-certmanager-controller

--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -18,6 +18,9 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
@@ -31,6 +34,9 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: net-certmanager-webhook
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: knative-serving
         role: net-certmanager-webhook
         serving.knative.dev/release: devel
     spec:

--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -18,9 +18,9 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
@@ -34,9 +34,9 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: net-certmanager-webhook
-        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/component: net-certmanager
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/name: knative-serving
         role: net-certmanager-webhook
         serving.knative.dev/release: devel
     spec:

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,7 +18,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -28,7 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -43,7 +43,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,6 +18,9 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 ---
 kind: ClusterRole
@@ -25,6 +28,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
@@ -37,6 +43,9 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount

--- a/test/config/300-certificate.yaml
+++ b/test/config/300-certificate.yaml
@@ -17,6 +17,9 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/test/config/300-certificate.yaml
+++ b/test/config/300-certificate.yaml
@@ -17,7 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/test/config/autotls/certmanager/http01/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/http01/config-certmanager.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/test/config/autotls/certmanager/http01/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/http01/config-certmanager.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:

--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:


### PR DESCRIPTION
# Changes

Adds Kubernetes recommended labels to networking as discussed in https://github.com/knative/networking/issues/552

Note that changes to the labels in `vendor/knative.dev/networking` should be handled by the automation once https://github.com/knative/networking/pull/555 merges. 

/kind enhancement