### PR TITLE
Updates webhook to use app.kubernetes.io selector label

### DIFF
--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -35,7 +35,7 @@ webhooks:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   namespaceSelector:
     matchExpressions:
-    - key: app.kubernetes.io/part-of
+    - key: app.kubernetes.io/name
       operator: In
       values:
       - knative-serving

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -35,5 +35,7 @@ webhooks:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   namespaceSelector:
     matchExpressions:
-    - key: serving.knative.dev/release
-      operator: Exists
+    - key: app.kubernetes.io/part-of
+      operator: In
+      values:
+      - knative-serving

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -34,8 +34,5 @@ webhooks:
   sideEffects: None
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   namespaceSelector:
-    matchExpressions:
-    - key: app.kubernetes.io/name
-      operator: In
-      values:
-      - knative-serving
+    matchLabels:
+      app.kubernetes.io/name: knative-serving


### PR DESCRIPTION
# Changes

As part of https://github.com/knative/serving/issues/12215 we're planning to transition from the `serving.knative.dev/release` label to the recommended `app.kubernetes.io` label in Serving. This PR updates the net-certmanager validating webhook to use the new label.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Switches selectors for Knative resources to use the recommended `app.kubernetes.io` labels
```

/assign @dprotaso 