### PR TITLE
[WIP] Removing deprecated serving.knative.dev/release labels

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 webhooks:
 - admissionReviewVersions:

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -21,5 +21,4 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
 

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -36,7 +35,6 @@ spec:
         app.kubernetes.io/component: net-certmanager
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-serving
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:
@@ -90,7 +88,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
   name: net-certmanager-controller
   namespace: knative-serving

--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -38,7 +37,6 @@ spec:
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-serving
         role: net-certmanager-webhook
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   ports:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
+    echo "Tagged release, updating release labels to app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
-    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,7 +30,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
-    serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -46,7 +44,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
-    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller

--- a/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |

--- a/test/config/autotls/certmanager/http01/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/http01/config-certmanager.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |

--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-certmanager
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Previously agreed these labels would be dropped in release v1.4
Follow on to #326 , #351 
See https://github.com/knative/serving/issues/12215 for more details.

**Release Note**

```release-note
`serving.knative.dev/release` labels, deprecated in v1.3, have been removed. Please switch over to using `app.kubernetes.io/name: knative-serving` and `app.kuberentes.io/version: devel`.
```

(wip to let the CI check for any issues...)