### PR TITLE
Allow creating certificates for DNS names longer than 63 charaters with cert-manager.

### DIFF
--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -30,6 +30,12 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 	if len(knCert.Spec.DNSNames) > 0 {
 		commonName = knCert.Spec.DNSNames[0]
 	}
+	if len(commonName) > 63 {
+		// Max length of a CN for cert-manager is 64 characters:
+		// https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+		commonName = commonName[:63]
+	}
+
 	cert := &cmv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            knCert.Name,


### PR DESCRIPTION
Fixes #214

I can choose a different common Name for this if needed, such as the metadata.name of the cert, or the first DNS segment.

* 🐛  Currently, `cert-manager` cannot issue certificates for Knative Services where the `len(service name) + len(namespace) + len(DNSSuffix)` > 62 characters (plus two `.` joining dots), because the certificate `commonName` is beyond the length allowed by the `Certificate` resource (this is blocked during validation).

# Release Note
```release-note
Add common name to cert manager certificate
```