### PR TITLE
Add secret label for filtering informers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cert-manager/cert-manager v1.8.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.6
+	github.com/hashicorp/golang-lru v0.5.4
 	go.uber.org/zap v1.19.1
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
@@ -44,7 +45,6 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -97,4 +97,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace knative.dev/networking => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0
+replace knative.dev/networking => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cert-manager/cert-manager v1.8.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.6
-	github.com/hashicorp/golang-lru v0.5.4
 	go.uber.org/zap v1.19.1
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
@@ -45,6 +44,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -96,3 +96,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace knative.dev/networking => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 	knative.dev/hack v0.0.0-20220506160929-a8076b0510ed
-	knative.dev/networking v0.0.0-20220505013701-91dcb36802a9
+	knative.dev/networking v0.0.0-20220516202057-7363ea66ba54
 	knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3
 )
 
@@ -96,5 +96,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace knative.dev/networking => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf

--- a/go.sum
+++ b/go.sum
@@ -433,6 +433,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/knative/networking v0.0.0-20220516202057-7363ea66ba54 h1:7c2uuNiAsc4OlKLD3vcb0g8qcIwRJ0TgpzE5T4IM7x4=
+github.com/knative/networking v0.0.0-20220516202057-7363ea66ba54/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -1271,6 +1273,10 @@ knative.dev/hack v0.0.0-20220427014036-5f473869d377/go.mod h1:PHt8x8yX5Z9pPquBEf
 knative.dev/hack v0.0.0-20220503220458-46c77f157e20/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20220506160929-a8076b0510ed h1:6mFHY1IFMRnO9O1z9q6xL9mAy6Gpm8SmRQ2KbahXKz0=
 knative.dev/hack v0.0.0-20220506160929-a8076b0510ed/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 h1:3/5bRIjG/cHKCQVmD/lMVCFKaym1U+0+Hlah25sF8c8=
+knative.dev/networking v0.0.0-20220505013701-91dcb36802a9/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
+knative.dev/networking v0.0.0-20220516202057-7363ea66ba54 h1:Zu1scweYeLGu/5oCezvss+IzwvBrxf/AZG2xifogXVQ=
+knative.dev/networking v0.0.0-20220516202057-7363ea66ba54/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 knative.dev/pkg v0.0.0-20220503223858-245166458ef4/go.mod h1:NXK3p/UMCbFybBM9xQGii3TuMN/WKHByXcYsTwZ6Y6U=
 knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3 h1:odf5hudTbupqdYDsxeqofZtMsZuU0FqPZqWI6xETYIA=
 knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3/go.mod h1:mRzBIY8eoQurpADZ4+3LzNuucKOBhsSvhX6lXqMVpIc=

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0 h1:qeUQIQWeWP/pSzeAVTH8nZtb+3KBf/J1nVb44C3rt+8=
+github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -1267,8 +1269,6 @@ knative.dev/hack v0.0.0-20220427014036-5f473869d377/go.mod h1:PHt8x8yX5Z9pPquBEf
 knative.dev/hack v0.0.0-20220503220458-46c77f157e20/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20220506160929-a8076b0510ed h1:6mFHY1IFMRnO9O1z9q6xL9mAy6Gpm8SmRQ2KbahXKz0=
 knative.dev/hack v0.0.0-20220506160929-a8076b0510ed/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 h1:3/5bRIjG/cHKCQVmD/lMVCFKaym1U+0+Hlah25sF8c8=
-knative.dev/networking v0.0.0-20220505013701-91dcb36802a9/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 knative.dev/pkg v0.0.0-20220503223858-245166458ef4/go.mod h1:NXK3p/UMCbFybBM9xQGii3TuMN/WKHByXcYsTwZ6Y6U=
 knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3 h1:odf5hudTbupqdYDsxeqofZtMsZuU0FqPZqWI6xETYIA=
 knative.dev/pkg v0.0.0-20220505013700-a8b7d99374a3/go.mod h1:mRzBIY8eoQurpADZ4+3LzNuucKOBhsSvhX6lXqMVpIc=

--- a/go.sum
+++ b/go.sum
@@ -585,6 +585,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0 h1:qeUQIQWeWP/pSzeAVTH8nZtb+3KBf/J1nVb44C3rt+8=
 github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
+github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf h1:Kge6pas0jW6yr2RnZ6tWArbUSIaqeigdm0AF+2uCzh4=
+github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/go.sum
+++ b/go.sum
@@ -585,10 +585,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0 h1:qeUQIQWeWP/pSzeAVTH8nZtb+3KBf/J1nVb44C3rt+8=
-github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
-github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf h1:Kge6pas0jW6yr2RnZ6tWArbUSIaqeigdm0AF+2uCzh4=
-github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf/go.mod h1:+H5KnK/r/4/WtRRacuQuuGEjCn0961q2o7gwl+FoZfo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -46,7 +46,7 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			IssuerRef:  *cmConfig.IssuerRef,
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
 				Labels: map[string]string{
-					networking.CertifcateUIDLabelKey: string(knCert.GetUID()),
+					networking.CertificateUIDLabelKey: string(knCert.GetUID()),
 				}},
 		},
 	}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -17,13 +17,10 @@ limitations under the License.
 package resources
 
 import (
-	"regexp"
-
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/net-certmanager/pkg/reconciler/certificate/config"
-	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 )
@@ -49,21 +46,11 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 			IssuerRef:  *cmConfig.IssuerRef,
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
 				Labels: map[string]string{
-					network.SecretInformerLabelKey: getLabelFromCertName(knCert.Name),
+					networking.CertifcateUIDLabelKey: string(knCert.GetUID()),
 				}},
 		},
 	}
 	return cert
-}
-
-// K8s names don't comply with Label requirements out of the box
-func getLabelFromCertName(name string) string {
-	reg, _ := regexp.Compile("[^a-zA-Z0-9-]+")
-	res := reg.ReplaceAllString(name, "")
-	if len(res) > validation.LabelValueMaxLength {
-		return res[0 : validation.LabelValueMaxLength-1]
-	}
-	return res
 }
 
 // GetReadyCondition gets the ready condition of a Cert-Manager `Certificate`.

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/net-certmanager/pkg/reconciler/certificate/config"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 )
@@ -84,7 +85,7 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 				Name: "Letsencrypt-issuer",
 			},
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
-				Labels: map[string]string{"certificate.networking.knative.dev": "test-cert"},
+				Labels: map[string]string{networking.CertifcateUIDLabelKey: ""},
 			},
 		},
 	}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -85,7 +85,7 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 				Name: "Letsencrypt-issuer",
 			},
 			SecretTemplate: &cmv1.CertificateSecretTemplate{
-				Labels: map[string]string{networking.CertifcateUIDLabelKey: ""},
+				Labels: map[string]string{networking.CertificateUIDLabelKey: ""},
 			},
 		},
 	}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -83,6 +83,9 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 				Kind: "ClusterIssuer",
 				Name: "Letsencrypt-issuer",
 			},
+			SecretTemplate: &cmv1.CertificateSecretTemplate{
+				Labels: map[string]string{"certificate.networking.knative.dev": "test-cert"},
+			},
 		},
 	}
 	got := MakeCertManagerCertificate(cmConfig, cert)

--- a/vendor/knative.dev/networking/pkg/apis/networking/register.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/register.go
@@ -22,6 +22,9 @@ const (
 	// GroupName is the name for the networking API group.
 	GroupName = "networking.internal.knative.dev"
 
+	// CertifcateUIDLabelKey is used to specify a label selector for informers listing ingress secrets.
+	CertifcateUIDLabelKey = GroupName + "/certficate-uid"
+
 	// IngressLabelKey is the label key attached to underlying network programming
 	// resources to indicate which Ingress triggered their creation.
 	IngressLabelKey = GroupName + "/ingress"

--- a/vendor/knative.dev/networking/pkg/apis/networking/register.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/register.go
@@ -23,7 +23,7 @@ const (
 	GroupName = "networking.internal.knative.dev"
 
 	// CertifcateUIDLabelKey is used to specify a label selector for informers listing ingress secrets.
-	CertifcateUIDLabelKey = GroupName + "/certficate-uid"
+	CertificateUIDLabelKey = GroupName + "/certificate-uid"
 
 	// IngressLabelKey is the label key attached to underlying network programming
 	// resources to indicate which Ingress triggered their creation.

--- a/vendor/knative.dev/networking/pkg/network.go
+++ b/vendor/knative.dev/networking/pkg/network.go
@@ -211,6 +211,9 @@ const (
 	// QueueProxyCertKey is the config for the secret name, which stores certificates
 	// to serve the TLS traffic from activator to queue-proxy.
 	QueueProxyCertKey = "queue-proxy-cert-secret"
+
+	// SecretInformerLabelKey is used to specify a label selector for informers listing ingress secrets.
+	SecretInformerLabelKey = "certificate.networking.knative.dev"
 )
 
 // DomainTemplateValues are the available properties people can choose from

--- a/vendor/knative.dev/networking/pkg/network.go
+++ b/vendor/knative.dev/networking/pkg/network.go
@@ -211,9 +211,6 @@ const (
 	// QueueProxyCertKey is the config for the secret name, which stores certificates
 	// to serve the TLS traffic from activator to queue-proxy.
 	QueueProxyCertKey = "queue-proxy-cert-secret"
-
-	// SecretInformerLabelKey is used to specify a label selector for informers listing ingress secrets.
-	SecretInformerLabelKey = "certificate.networking.knative.dev"
 )
 
 // DomainTemplateValues are the available properties people can choose from

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -873,7 +873,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20220506160929-a8076b0510ed
 ## explicit; go 1.14
 knative.dev/hack
-# knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0
+# knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf
 ## explicit; go 1.16
 knative.dev/networking/config
 knative.dev/networking/pkg
@@ -990,4 +990,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# knative.dev/networking => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0
+# knative.dev/networking => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -873,7 +873,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20220506160929-a8076b0510ed
 ## explicit; go 1.14
 knative.dev/hack
-# knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf
+# knative.dev/networking v0.0.0-20220516202057-7363ea66ba54
 ## explicit; go 1.16
 knative.dev/networking/config
 knative.dev/networking/pkg
@@ -990,4 +990,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# knative.dev/networking => github.com/skonto/networking v0.0.0-20220516113028-b96cbdcc21bf

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -873,7 +873,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20220506160929-a8076b0510ed
 ## explicit; go 1.14
 knative.dev/hack
-# knative.dev/networking v0.0.0-20220505013701-91dcb36802a9
+# knative.dev/networking v0.0.0-20220505013701-91dcb36802a9 => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0
 ## explicit; go 1.16
 knative.dev/networking/config
 knative.dev/networking/pkg
@@ -990,3 +990,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# knative.dev/networking => github.com/skonto/networking v0.0.0-20220511230850-2595d6d1c7c0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds a label using the secret template for supporting filtering informers for the generated secrets
- Part of the work here: https://github.com/knative-sandbox/net-istio/pull/920



<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Secrets automatically generated due to certificate creation are labeled with a special label key to support proper filtering from K8s informers in components that consume them.
```