### PR TITLE
watch certificate in renewing state

### DIFF
--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hash/adler32"
 	"strconv"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -56,12 +57,14 @@ const (
 	notReconciledMessage = "Cert-Manager certificate has not yet been reconciled."
 	httpDomainLabel      = "acme.cert-manager.io/http-domain"
 	httpChallengePath    = "/.well-known/acme-challenge"
-	renewReason          = "Renewing"
+	renewingEvent        = "Renewing"
 )
 
 // It comes from cert-manager status:
 // https://github.com/cert-manager/cert-manager/blob/b7e83b53820e712e7cf6b8dce3e5a050f249da79/pkg/controller/certificates/sync.go#L130
 var notReadyReasons = sets.NewString("InProgress", "Pending", "TemporaryCertificate")
+
+var certificateCondSet = apis.NewLivingConditionSet(apis.ConditionReady)
 
 // Reconciler implements controller.Reconciler for Certificate resources.
 type Reconciler struct {
@@ -105,11 +108,19 @@ func (c *Reconciler) reconcile(ctx context.Context, knCert *v1alpha1.Certificate
 	}
 
 	knCert.Status.NotAfter = cmCert.Status.NotAfter
+
+	// add a temporary renewing state when cm certificate is being renewed
+	// this will reconfigure the ingress in order to route HTTP01 challenge traffic
+	// before cm certificate expiration
+	// https://github.com/knative-sandbox/net-certmanager/issues/416
+	renewing := false
+	if cmCert.Status.RenewalTime != nil && time.Now().After(cmCert.Status.RenewalTime.Time) {
+		renewing = true
+	}
+
 	// Propagate cert-manager Certificate status to Knative Certificate.
 	cmCertReadyCondition := resources.GetReadyCondition(cmCert)
 	logger.Infof("cm cert condition %v.", cmCertReadyCondition)
-	cmCertRenewingCondition := resources.GetRenewingCondition(cmCert)
-	logger.Infof("cm cert renew condition %v.", cmCertRenewingCondition)
 
 	switch {
 	case cmCertReadyCondition == nil:
@@ -119,10 +130,17 @@ func (c *Reconciler) reconcile(ctx context.Context, knCert *v1alpha1.Certificate
 		knCert.Status.MarkNotReady(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
 		return c.setHTTP01Challenges(knCert, cmCert)
 	case cmCertReadyCondition.Status == cmmeta.ConditionTrue:
-		if cmCertRenewingCondition != nil && cmCertRenewingCondition.Reason == renewReason {
-			knCert.Status.MarkNotReady(cmCertReadyCondition.Reason, cmCertReadyCondition.Message)
+		if renewing {
+			// set renew condition
+			renewCondition := apis.Condition{
+				Type:   renewingEvent,
+				Status: corev1.ConditionTrue,
+			}
+			certificateCondSet.Manage(&knCert.Status).SetCondition(renewCondition)
 			return c.setHTTP01Challenges(knCert, cmCert)
 		}
+		// remove renew condition if exists
+		certificateCondSet.Manage(&knCert.Status).ClearCondition(renewingEvent)
 		knCert.Status.MarkReady()
 		knCert.Status.HTTP01Challenges = []v1alpha1.HTTP01Challenge{}
 	case cmCertReadyCondition.Status == cmmeta.ConditionFalse:

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -62,3 +62,13 @@ func GetReadyCondition(cmCert *cmv1.Certificate) *cmv1.CertificateCondition {
 	}
 	return nil
 }
+
+// GetRenewingCondition gets the renewing state of a Cert-manager `Certificate`.
+func GetRenewingCondition(cmCert *cmv1.Certificate) *cmv1.CertificateCondition {
+	for _, cond := range cmCert.Status.Conditions {
+		if cond.Type == cmv1.CertificateConditionIssuing {
+			return &cond
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -62,13 +62,3 @@ func GetReadyCondition(cmCert *cmv1.Certificate) *cmv1.CertificateCondition {
 	}
 	return nil
 }
-
-// GetRenewingCondition gets the renewing state of a Cert-manager `Certificate`.
-func GetRenewingCondition(cmCert *cmv1.Certificate) *cmv1.CertificateCondition {
-	for _, cond := range cmCert.Status.Conditions {
-		if cond.Type == cmv1.CertificateConditionIssuing {
-			return &cond
-		}
-	}
-	return nil
-}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -141,35 +141,6 @@ func TestGetReadyCondition(t *testing.T) {
 	}
 }
 
-func TestGetRenewingCondition(t *testing.T) {
-	tests := []struct {
-		name          string
-		cmCertificate *cmv1.Certificate
-		want          *cmv1.CertificateCondition
-	}{{
-		name:          "renewing",
-		cmCertificate: makeTestCertificate(cmmeta.ConditionTrue, cmv1.CertificateConditionIssuing, "Renewing", "Renewing certificate"),
-		want: &cmv1.CertificateCondition{
-			Type:    cmv1.CertificateConditionIssuing,
-			Status:  cmmeta.ConditionTrue,
-			Reason:  "Renewing",
-			Message: "Renewing certificate",
-		}}, {
-		name:          "nothing to renew",
-		cmCertificate: makeTestCertificate(cmmeta.ConditionUnknown, cmv1.CertificateConditionReady, "ready", "ready"),
-		want:          nil,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := GetRenewingCondition(test.cmCertificate)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("GetReadyCondition (-want, +got) = %s", diff)
-			}
-		})
-	}
-}
-
 func makeTestCertificate(condStatus cmmeta.ConditionStatus, condType cmv1.CertificateConditionType, reason, message string) *cmv1.Certificate {
 	cert := &cmv1.Certificate{
 		Status: cmv1.CertificateStatus{

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -102,7 +102,7 @@ func TestGetReadyCondition(t *testing.T) {
 		want          *cmv1.CertificateCondition
 	}{{
 		name:          "ready",
-		cmCertificate: makeTestCertificate(cmmeta.ConditionTrue, "ready", "ready"),
+		cmCertificate: makeTestCertificate(cmmeta.ConditionTrue, cmv1.CertificateConditionReady, "ready", "ready"),
 		want: &cmv1.CertificateCondition{
 			Type:    cmv1.CertificateConditionReady,
 			Status:  cmmeta.ConditionTrue,
@@ -110,7 +110,7 @@ func TestGetReadyCondition(t *testing.T) {
 			Message: "ready",
 		}}, {
 		name:          "not ready",
-		cmCertificate: makeTestCertificate(cmmeta.ConditionFalse, "not ready", "not ready"),
+		cmCertificate: makeTestCertificate(cmmeta.ConditionFalse, cmv1.CertificateConditionReady, "not ready", "not ready"),
 		want: &cmv1.CertificateCondition{
 			Type:    cmv1.CertificateConditionReady,
 			Status:  cmmeta.ConditionFalse,
@@ -118,14 +118,18 @@ func TestGetReadyCondition(t *testing.T) {
 			Message: "not ready",
 		}}, {
 		name:          "unknow",
-		cmCertificate: makeTestCertificate(cmmeta.ConditionUnknown, "unknown", "unknown"),
+		cmCertificate: makeTestCertificate(cmmeta.ConditionUnknown, cmv1.CertificateConditionReady, "unknown", "unknown"),
 		want: &cmv1.CertificateCondition{
 			Type:    cmv1.CertificateConditionReady,
 			Status:  cmmeta.ConditionUnknown,
 			Reason:  "unknown",
 			Message: "unknown",
-		},
-	}}
+		}}, {
+		name:          "condition not ready",
+		cmCertificate: makeTestCertificate(cmmeta.ConditionTrue, cmv1.CertificateConditionIssuing, "Renewing", "Renewing certificate"),
+		want:          nil,
+	},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -137,12 +141,41 @@ func TestGetReadyCondition(t *testing.T) {
 	}
 }
 
-func makeTestCertificate(cond cmmeta.ConditionStatus, reason, message string) *cmv1.Certificate {
+func TestGetRenewingCondition(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmCertificate *cmv1.Certificate
+		want          *cmv1.CertificateCondition
+	}{{
+		name:          "renewing",
+		cmCertificate: makeTestCertificate(cmmeta.ConditionTrue, cmv1.CertificateConditionIssuing, "Renewing", "Renewing certificate"),
+		want: &cmv1.CertificateCondition{
+			Type:    cmv1.CertificateConditionIssuing,
+			Status:  cmmeta.ConditionTrue,
+			Reason:  "Renewing",
+			Message: "Renewing certificate",
+		}}, {
+		name:          "nothing to renew",
+		cmCertificate: makeTestCertificate(cmmeta.ConditionUnknown, cmv1.CertificateConditionReady, "ready", "ready"),
+		want:          nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetRenewingCondition(test.cmCertificate)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("GetReadyCondition (-want, +got) = %s", diff)
+			}
+		})
+	}
+}
+
+func makeTestCertificate(condStatus cmmeta.ConditionStatus, condType cmv1.CertificateConditionType, reason, message string) *cmv1.Certificate {
 	cert := &cmv1.Certificate{
 		Status: cmv1.CertificateStatus{
 			Conditions: []cmv1.CertificateCondition{{
-				Type:    cmv1.CertificateConditionReady,
-				Status:  cond,
+				Type:    condType,
+				Status:  condStatus,
 				Reason:  reason,
 				Message: message,
 			}},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

🐛  certificate will not be renewed immediately after the renewal process is launched and let's encrypt will call the `user-container` as a consequence  

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #416 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
This will configure envoy with the right routes so let's encrpt traffic will no be forwarded to `user-container`
```


<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
