### PR TITLE
Bring back commented out tests

### DIFF
--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -16,79 +16,78 @@ limitations under the License.
 
 package config
 
-//
-//import (
-//	"testing"
-//
-//	"github.com/google/go-cmp/cmp"
-//	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-//	corev1 "k8s.io/api/core/v1"
-//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-//	. "knative.dev/pkg/configmap/testing"
-//	"knative.dev/pkg/system"
-//	_ "knative.dev/pkg/system/testing"
-//)
-//
-//func TestCertManagerConfig(t *testing.T) {
-//	cm, example := ConfigMapsFromTestFile(t, CertManagerConfigName)
-//
-//	if _, err := NewCertManagerConfigFromConfigMap(cm); err != nil {
-//		t.Errorf("NewCertManagerConfigFromConfigMap(actual) = %v", err)
-//	}
-//
-//	if _, err := NewCertManagerConfigFromConfigMap(example); err != nil {
-//		t.Errorf("NewCertManagerConfigFromConfigMap(actual) = %v", err)
-//	}
-//}
-//
-//func TestIssuerRef(t *testing.T) {
-//	isserRefCases := []struct {
-//		name       string
-//		wantErr    bool
-//		wantConfig *CertManagerConfig
-//		config     *corev1.ConfigMap
-//	}{{
-//		name:       "invalid format",
-//		wantErr:    true,
-//		wantConfig: (*CertManagerConfig)(nil),
-//		config: &corev1.ConfigMap{
-//			ObjectMeta: metav1.ObjectMeta{
-//				Namespace: system.Namespace(),
-//				Name:      CertManagerConfigName,
-//			},
-//			Data: map[string]string{
-//				issuerRefKey: "wrong format",
-//			},
-//		},
-//	}, {
-//		name:    "valid IssuerRef",
-//		wantErr: false,
-//		wantConfig: &CertManagerConfig{
-//			IssuerRef: &cmmeta.ObjectReference{
-//				Name: "letsencrypt-issuer",
-//				Kind: "ClusterIssuer",
-//			},
-//		},
-//		config: &corev1.ConfigMap{
-//			ObjectMeta: metav1.ObjectMeta{
-//				Namespace: system.Namespace(),
-//				Name:      CertManagerConfigName,
-//			},
-//			Data: map[string]string{
-//				issuerRefKey: "kind: ClusterIssuer\nname: letsencrypt-issuer",
-//			},
-//		},
-//	}}
-//
-//	for _, tt := range isserRefCases {
-//		t.Run(tt.name, func(t *testing.T) {
-//			actualConfig, err := NewCertManagerConfigFromConfigMap(tt.config)
-//			if (err != nil) != tt.wantErr {
-//				t.Fatalf("Test: %q; NewCertManagerConfigFromConfigMap() error = %v, WantErr %v", tt.name, err, tt.wantErr)
-//			}
-//			if diff := cmp.Diff(actualConfig, tt.wantConfig); diff != "" {
-//				t.Fatalf("Want %v, but got %v", tt.wantConfig, actualConfig)
-//			}
-//		})
-//	}
-//}
+import (
+	"testing"
+
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	configmaptesting "knative.dev/pkg/configmap/testing"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestCertManagerConfig(t *testing.T) {
+	cm, example := configmaptesting.ConfigMapsFromTestFile(t, CertManagerConfigName)
+
+	if _, err := NewCertManagerConfigFromConfigMap(cm); err != nil {
+		t.Errorf("NewCertManagerConfigFromConfigMap(actual) = %v", err)
+	}
+
+	if _, err := NewCertManagerConfigFromConfigMap(example); err != nil {
+		t.Errorf("NewCertManagerConfigFromConfigMap(actual) = %v", err)
+	}
+}
+
+func TestIssuerRef(t *testing.T) {
+	isserRefCases := []struct {
+		name       string
+		wantErr    bool
+		wantConfig *CertManagerConfig
+		config     *corev1.ConfigMap
+	}{{
+		name:       "invalid format",
+		wantErr:    true,
+		wantConfig: (*CertManagerConfig)(nil),
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      CertManagerConfigName,
+			},
+			Data: map[string]string{
+				issuerRefKey: "wrong format",
+			},
+		},
+	}, {
+		name:    "valid IssuerRef",
+		wantErr: false,
+		wantConfig: &CertManagerConfig{
+			IssuerRef: &cmmeta.ObjectReference{
+				Name: "letsencrypt-issuer",
+				Kind: "ClusterIssuer",
+			},
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      CertManagerConfigName,
+			},
+			Data: map[string]string{
+				issuerRefKey: "kind: ClusterIssuer\nname: letsencrypt-issuer",
+			},
+		},
+	}}
+
+	for _, tt := range isserRefCases {
+		t.Run(tt.name, func(t *testing.T) {
+			actualConfig, err := NewCertManagerConfigFromConfigMap(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Test: %q; NewCertManagerConfigFromConfigMap() error = %v, WantErr %v", tt.name, err, tt.wantErr)
+			}
+			if diff := cmp.Diff(actualConfig, tt.wantConfig); diff != "" {
+				t.Fatalf("Want %v, but got %v", tt.wantConfig, actualConfig)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/certificate/config/store_test.go
+++ b/pkg/reconciler/certificate/config/store_test.go
@@ -16,37 +16,36 @@ limitations under the License.
 
 package config
 
-//
-//import (
-//	"context"
-//	"testing"
-//
-//	"github.com/google/go-cmp/cmp"
-//	. "knative.dev/pkg/configmap/testing"
-//	. "knative.dev/pkg/logging/testing"
-//)
-//
-//func TestStoreLoadWithContext(t *testing.T) {
-//	store := NewStore(TestLogger(t))
-//
-//	certManagerConfig := ConfigMapFromTestFile(t, CertManagerConfigName)
-//	store.OnConfigChanged(certManagerConfig)
-//	config := FromContext(store.ToContext(context.Background()))
-//
-//	expected, _ := NewCertManagerConfigFromConfigMap(certManagerConfig)
-//	if diff := cmp.Diff(expected, config.CertManager); diff != "" {
-//		t.Errorf("Unexpected CertManager config (-want, +got): %v", diff)
-//	}
-//}
-//
-//func TestStoreImmutableConfig(t *testing.T) {
-//	store := NewStore(TestLogger(t))
-//	store.OnConfigChanged(ConfigMapFromTestFile(t, CertManagerConfigName))
-//	config := store.Load()
-//
-//	config.CertManager.IssuerRef.Kind = "newKind"
-//	newConfig := store.Load()
-//	if newConfig.CertManager.IssuerRef.Kind == "newKind" {
-//		t.Error("CertManager config is not immutable")
-//	}
-//}
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	configmaptesting "knative.dev/pkg/configmap/testing"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestStoreLoadWithContext(t *testing.T) {
+	store := NewStore(logtesting.TestLogger(t))
+
+	certManagerConfig := configmaptesting.ConfigMapFromTestFile(t, CertManagerConfigName)
+	store.OnConfigChanged(certManagerConfig)
+	config := FromContext(store.ToContext(context.Background()))
+
+	expected, _ := NewCertManagerConfigFromConfigMap(certManagerConfig)
+	if diff := cmp.Diff(expected, config.CertManager); diff != "" {
+		t.Errorf("Unexpected CertManager config (-want, +got): %v", diff)
+	}
+}
+
+func TestStoreImmutableConfig(t *testing.T) {
+	store := NewStore(logtesting.TestLogger(t))
+	store.OnConfigChanged(configmaptesting.ConfigMapFromTestFile(t, CertManagerConfigName))
+	config := store.Load()
+
+	config.CertManager.IssuerRef.Kind = "newKind"
+	newConfig := store.Load()
+	if newConfig.CertManager.IssuerRef.Kind == "newKind" {
+		t.Error("CertManager config is not immutable")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -957,6 +957,7 @@ knative.dev/pkg/codegen/cmd/injection-gen/args
 knative.dev/pkg/codegen/cmd/injection-gen/generators
 knative.dev/pkg/configmap
 knative.dev/pkg/configmap/informer
+knative.dev/pkg/configmap/testing
 knative.dev/pkg/controller
 knative.dev/pkg/environment
 knative.dev/pkg/hack


### PR DESCRIPTION
- With https://github.com/knative-sandbox/net-certmanager/commit/0cd6d51bc9c013cd1e8a7e7a83de6fa2f983b1e5 some tests were accidentally commented out. This brings them back.
