### PR TITLE
followup from #214

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cert-manager/cert-manager v1.8.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.8
+	github.com/google/uuid v1.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	go.uber.org/zap v1.19.1
 	k8s.io/api v0.25.4
@@ -43,7 +44,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cert-manager/cert-manager v1.8.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.8
+	github.com/martinlindhe/base36 v1.1.1
 	go.uber.org/zap v1.19.1
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/martinlindhe/base36 v1.1.1 h1:1F1MZ5MGghBXDZ2KJ3QfxmiydlWOGB8HCEtkap5NkVg=
+github.com/martinlindhe/base36 v1.1.1/go.mod h1:vMS8PaZ5e/jV9LwFKlm0YLnXl/hpOihiBxKkIoc3g08=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -318,6 +318,40 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/knCert",
 	}, {
+		Name: "set Knative Certificate not ready status with details when common name is too long",
+		Objects: []runtime.Object{
+			knCertDomainTooLong("knCert", "foo", &v1alpha1.CertificateStatus{}, 0),
+		},
+		WantErr: true,
+		WantEvents: []string{
+			"Warning InternalError error creating Certmanager Certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: knCertDomainTooLong("knCert", "foo",
+				&v1alpha1.CertificateStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 0,
+						Conditions: duckv1.Conditions{
+							{
+								Type:     "CreateCertManagerCertificate",
+								Status:   corev1.ConditionFalse,
+								Reason:   "CommonName Too Long",
+								Message:  "error creating Certmanager Certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
+								Severity: apis.ConditionSeverityError,
+							},
+							{
+								Type:     v1alpha1.CertificateConditionReady,
+								Status:   corev1.ConditionUnknown,
+								Severity: apis.ConditionSeverityError,
+								Reason:   "ReconcileFailed",
+								Message:  "Cert-Manager certificate has not yet been reconciled.",
+							},
+						},
+					},
+				}, 0),
+		}},
+		Key: "foo/knCert",
+	}, {
 		Name: "set Knative Certificate renewing status with CM Certificate Renewing status",
 		Objects: []runtime.Object{
 			knCertWithStatus("knCert", "foo", &v1alpha1.CertificateStatus{
@@ -660,6 +694,25 @@ func certmanagerConfig() *config.CertManagerConfig {
 
 func knCert(name, namespace string) *v1alpha1.Certificate {
 	return knCertWithStatus(name, namespace, &v1alpha1.CertificateStatus{})
+}
+
+func knCertDomainTooLong(name, namespace string, status *v1alpha1.CertificateStatus, gen int) *v1alpha1.Certificate {
+	return &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Generation: int64(gen),
+			Annotations: map[string]string{
+				netapi.CertificateClassAnnotationKey: netcfg.CertManagerCertificateClassName,
+			},
+		},
+		Spec: v1alpha1.CertificateSpec{
+			DNSNames:   []string{"hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname"},
+			Domain:     "reallyreallyreallyreallyreallyreallyreallylong.domainname",
+			SecretName: "secret0",
+		},
+		Status: *status,
+	}
 }
 
 func knCertWithStatus(name, namespace string, status *v1alpha1.CertificateStatus) *v1alpha1.Certificate {

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -333,18 +333,11 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 0,
 						Conditions: duckv1.Conditions{
 							{
-								Type:     "CreateCertManagerCertificate",
+								Type:     v1alpha1.CertificateConditionReady,
 								Status:   corev1.ConditionFalse,
+								Severity: apis.ConditionSeverityError,
 								Reason:   "CommonName Too Long",
 								Message:  "error creating Certmanager Certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
-								Severity: apis.ConditionSeverityError,
-							},
-							{
-								Type:     v1alpha1.CertificateConditionReady,
-								Status:   corev1.ConditionUnknown,
-								Severity: apis.ConditionSeverityError,
-								Reason:   "ReconcileFailed",
-								Message:  "Cert-Manager certificate has not yet been reconciled.",
 							},
 						},
 					},

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -59,7 +59,7 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 		if knCert.Spec.Domain != "" && knCert.Spec.Domain != commonName {
 			//Split out the domain, and create a hash of the remaining part
 			domainSuffix := "." + knCert.Spec.Domain
-			prefix := strings.SplitN(commonName, domainSuffix, 2)[0]
+			prefix := strings.TrimSuffix(commonName, domainSuffix)
 			if len(prefix) > base36Len {
 				attemptedToShorten = true
 

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -56,7 +56,7 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 				return nil, fmt.Errorf("error executing the CommonNameTemplate: %w", err)
 			}
 
-			commonName = kmeta.ChildName(buf.String(), "")
+			commonName = buf.String()
 			dnsNames = append(dnsNames, commonName)
 		} else {
 			return nil, fmt.Errorf("error creating Certmanager Certificate: %s", "commonName too long and no Domain available")

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -17,27 +17,33 @@ limitations under the License.
 package resources
 
 import (
-	"crypto/md5"
 	"fmt"
 	"strings"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/net-certmanager/pkg/reconciler/certificate/config"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+
+	"github.com/martinlindhe/base36"
 )
 
 const (
-	longest = 63
-	md5Len  = 32
+	longest                               = 63
+	base36Len                             = 25
+	CreateCertManagerCertificateCondition = "CreateCertManagerCertificate"
 )
 
 // MakeCertManagerCertificate creates a Cert-Manager `Certificate` for requesting a SSL certificate.
-func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1alpha1.Certificate) (*cmv1.Certificate, error) {
+func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1alpha1.Certificate) (*cmv1.Certificate, *apis.Condition) {
 	var commonName string
 	var dnsNames []string
+	attemptedToShorten := false
 
 	if len(knCert.Spec.DNSNames) > 0 {
 		commonName = knCert.Spec.DNSNames[0]
@@ -50,22 +56,79 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 	// The KCert controller requests new certs with same domain names, but a different CN if spec.domain is set and the other domain name would be too long
 	// cert-manager Certificates are updated only if the existing domain name kept them from being issued.
 	if len(commonName) > longest {
-		if knCert.Spec.Domain != "" {
+		if knCert.Spec.Domain != "" && knCert.Spec.Domain != commonName {
 			//Split out the domain, and create a hash of the remaining part
 			domainSuffix := "." + knCert.Spec.Domain
 			prefix := strings.SplitN(commonName, domainSuffix, 2)[0]
-			if len(prefix) > md5Len {
-				prefix = fmt.Sprintf("%x", md5.Sum([]byte(prefix)))
+			if len(prefix) > base36Len {
+				attemptedToShorten = true
+
+				parsedUUID, err := uuid.Parse(string(knCert.UID))
+				if err != nil {
+					return nil, &apis.Condition{
+						Type:   apis.ConditionType(CreateCertManagerCertificateCondition),
+						Status: corev1.ConditionFalse,
+						Reason: "Failed To Parse UID",
+						Message: fmt.Sprintf(
+							"error creating Certmanager Certificate: failed to parse UID (%s) on KCert (%s): %s",
+							knCert.UID,
+							knCert.Name,
+							err,
+						),
+					}
+				}
+				parsedUUIDbytes := [16]byte(parsedUUID)
+				prefix = strings.ToLower(base36.EncodeBytes(parsedUUIDbytes[:]))
 			}
 			commonName = prefix + domainSuffix
 
 			//If the new name is still too long, then error
 			if len(commonName) > longest {
-				return nil, fmt.Errorf("error creating Certmanager Certificate: cannot create valid length CommonName: %s", "Domain plus md5 hash of name+namespace data still longer than 63 characters.")
+				if attemptedToShorten {
+					return nil, &apis.Condition{
+						Type:   apis.ConditionType(CreateCertManagerCertificateCondition),
+						Status: corev1.ConditionFalse,
+						Reason: "CommonName Too Long After Shortening",
+						Message: fmt.Sprintf(
+							"error creating Certmanager Certificate: cannot create valid length CommonName: (%s) still longer than 63 characters after shortening",
+							commonName,
+						),
+					}
+				} else {
+					return nil, &apis.Condition{
+						Type:   apis.ConditionType(CreateCertManagerCertificateCondition),
+						Status: corev1.ConditionFalse,
+						Reason: "CommonName Too Long",
+						Message: fmt.Sprintf(
+							"error creating Certmanager Certificate: cannot create valid length CommonName: (%s) still longer than 63 characters, cannot shorten",
+							commonName,
+						),
+					}
+				}
 			}
 			dnsNames = append(dnsNames, commonName)
 		} else {
-			return nil, fmt.Errorf("error creating Certmanager Certificate: %s", "commonName too long and no Domain available")
+			if knCert.Spec.Domain == commonName {
+				return nil, &apis.Condition{
+					Type:   apis.ConditionType(CreateCertManagerCertificateCondition),
+					Status: corev1.ConditionFalse,
+					Reason: "DomainMapping Name Too Long",
+					Message: fmt.Sprintf(
+						"error creating Certmanager Certificate: DomainMapping name (%s) longer than 63 characters",
+						commonName,
+					),
+				}
+			} else {
+				return nil, &apis.Condition{
+					Type:   apis.ConditionType(CreateCertManagerCertificateCondition),
+					Status: corev1.ConditionFalse,
+					Reason: "CommonName Too Long",
+					Message: fmt.Sprintf(
+						"error creating Certmanager Certificate: CommonName (%s) too long and no Domain available",
+						commonName,
+					),
+				}
+			}
 		}
 
 	}

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -59,7 +59,7 @@ var cert = &v1alpha1.Certificate{
 }
 
 var (
-	longDomain         = fmt.Sprintf("%s.%s", strings.Repeat("a", 62), "com")
+	longDomain         = fmt.Sprintf("%s.%s", strings.Repeat("a", 54), "com")
 	longDNSNames       = []string{"host1." + longDomain, "host2." + longDomain}
 	certWithLongDomain = &v1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -125,7 +125,7 @@ func TestMakeCertManagerCertificate(t *testing.T) {
 	}
 }
 
-func TestMakeCertManagerCertificateValidLengthCommonName(t *testing.T) {
+func TestMakeCertManagerCertificateUseDomainTemplateWhenCommonNameIsTooLong(t *testing.T) {
 	want := &cmv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-cert",
@@ -141,8 +141,8 @@ func TestMakeCertManagerCertificateValidLengthCommonName(t *testing.T) {
 		},
 		Spec: cmv1.CertificateSpec{
 			SecretName: "secret0",
-			CommonName: "k.aaaaaaaaaaaaaaaaaaaaaaaaaaaaa5e9ef16706806dca9cc47a7d55eec088",
-			DNSNames:   append([]string{"k.aaaaaaaaaaaaaaaaaaaaaaaaaaaaa5e9ef16706806dca9cc47a7d55eec088"}, longDNSNames...),
+			CommonName: "k.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com",
+			DNSNames:   append([]string{"k.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com"}, longDNSNames...),
 			IssuerRef: cmmeta.ObjectReference{
 				Kind: "ClusterIssuer",
 				Name: "Letsencrypt-issuer",

--- a/third_party/VENDOR-LICENSE/github.com/martinlindhe/base36/LICENSE
+++ b/third_party/VENDOR-LICENSE/github.com/martinlindhe/base36/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Martin Lindhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/martinlindhe/base36/LICENSE
+++ b/vendor/github.com/martinlindhe/base36/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Martin Lindhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/martinlindhe/base36/README.md
+++ b/vendor/github.com/martinlindhe/base36/README.md
@@ -1,0 +1,28 @@
+# About
+
+[![GoDoc](https://godoc.org/github.com/martinlindhe/base36?status.svg)](https://godoc.org/github.com/martinlindhe/base36)
+
+Implements Base36 encoding and decoding, which is useful to represent
+large integers in a case-insensitive alphanumeric way.
+
+## Examples
+
+```go
+import "github.com/martinlindhe/base36"
+
+fmt.Println(base36.Encode(5481594952936519619))
+// Output: 15N9Z8L3AU4EB
+
+fmt.Println(base36.Decode("15N9Z8L3AU4EB"))
+// Output: 5481594952936519619
+
+fmt.Println(base36.EncodeBytes([]byte{1, 2, 3, 4}))
+// Output: A2F44
+
+fmt.Println(base36.DecodeToBytes("A2F44"))
+// Output: [1 2 3 4]
+```
+
+## License
+
+Under [MIT](LICENSE)

--- a/vendor/github.com/martinlindhe/base36/base36.go
+++ b/vendor/github.com/martinlindhe/base36/base36.go
@@ -1,0 +1,167 @@
+package base36
+
+import (
+	"math/big"
+	"strings"
+)
+
+var (
+	base36 = []byte{
+		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+		'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+		'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+		'U', 'V', 'W', 'X', 'Y', 'Z'}
+
+	//index = map[byte]int{
+	//	'0': 0, '1': 1, '2': 2, '3': 3, '4': 4,
+	//	'5': 5, '6': 6, '7': 7, '8': 8, '9': 9,
+	//	'A': 10, 'B': 11, 'C': 12, 'D': 13, 'E': 14,
+	//	'F': 15, 'G': 16, 'H': 17, 'I': 18, 'J': 19,
+	//	'K': 20, 'L': 21, 'M': 22, 'N': 23, 'O': 24,
+	//	'P': 25, 'Q': 26, 'R': 27, 'S': 28, 'T': 29,
+	//	'U': 30, 'V': 31, 'W': 32, 'X': 33, 'Y': 34,
+	//	'Z': 35,
+	//	'a': 10, 'b': 11, 'c': 12, 'd': 13, 'e': 14,
+	//	'f': 15, 'g': 16, 'h': 17, 'i': 18, 'j': 19,
+	//	'k': 20, 'l': 21, 'm': 22, 'n': 23, 'o': 24,
+	//	'p': 25, 'q': 26, 'r': 27, 's': 28, 't': 29,
+	//	'u': 30, 'v': 31, 'w': 32, 'x': 33, 'y': 34,
+	//	'z': 35,
+	//}
+	uint8Index = []uint64{
+		0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 1, 2,
+		3, 4, 5, 6, 7, 8, 9, 0, 0, 0,
+		0, 0, 0, 0, 10, 11, 12, 13, 14,
+		15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+		25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+		35, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13,
+		14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+		34, 35, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, // 256
+	}
+	pow36Index = []uint64{
+		1, 36, 1296, 46656, 1679616, 60466176,
+		2176782336, 78364164096, 2821109907456,
+		101559956668416, 3656158440062976,
+		131621703842267136, 4738381338321616896,
+		9223372036854775808,
+	}
+)
+
+// Encode encodes a number to base36.
+func Encode(value uint64) string {
+	var res [16]byte
+	var i int
+	for i = len(res) - 1; ; i-- {
+		res[i] = base36[value%36]
+		value /= 36
+		if value == 0 {
+			break
+		}
+	}
+
+	return string(res[i:])
+}
+
+// Decode decodes a base36-encoded string.
+func Decode(s string) uint64 {
+	if len(s) > 13 {
+		s = s[:12]
+	}
+	res := uint64(0)
+	l := len(s) - 1
+	for idx := 0; idx < len(s); idx++ {
+		c := s[l-idx]
+		res += uint8Index[c] * pow36Index[idx]
+	}
+	return res
+}
+
+var bigRadix = big.NewInt(36)
+var bigZero = big.NewInt(0)
+
+// EncodeBytesAsBytes encodes a byte slice to base36.
+func EncodeBytesAsBytes(b []byte) []byte {
+	x := new(big.Int)
+	x.SetBytes(b)
+
+	answer := make([]byte, 0, len(b)*136/100)
+	for x.Cmp(bigZero) > 0 {
+		mod := new(big.Int)
+		x.DivMod(x, bigRadix, mod)
+		answer = append(answer, base36[mod.Int64()])
+	}
+
+	// leading zero bytes
+	for _, i := range b {
+		if i != 0 {
+			break
+		}
+		answer = append(answer, base36[0])
+	}
+
+	// reverse
+	alen := len(answer)
+	for i := 0; i < alen/2; i++ {
+		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
+	}
+
+	return answer
+}
+
+// EncodeBytes encodes a byte slice to base36 string.
+func EncodeBytes(b []byte) string {
+	return string(EncodeBytesAsBytes(b))
+}
+
+// DecodeToBytes decodes a base36 string to a byte slice, using alphabet.
+func DecodeToBytes(b string) []byte {
+	alphabet := string(base36)
+	answer := big.NewInt(0)
+	j := big.NewInt(1)
+
+	for i := len(b) - 1; i >= 0; i-- {
+		tmp := strings.IndexAny(alphabet, string(b[i]))
+		if tmp == -1 {
+			return []byte("")
+		}
+		idx := big.NewInt(int64(tmp))
+		tmp1 := big.NewInt(0)
+		tmp1.Mul(j, idx)
+
+		answer.Add(answer, tmp1)
+		j.Mul(j, bigRadix)
+	}
+
+	tmpval := answer.Bytes()
+
+	var numZeros int
+	for numZeros = 0; numZeros < len(b); numZeros++ {
+		if b[numZeros] != alphabet[0] {
+			break
+		}
+	}
+	flen := numZeros + len(tmpval)
+	val := make([]byte, flen, flen)
+	copy(val[numZeros:], tmpval)
+
+	return val
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -145,6 +145,9 @@ github.com/kelseyhightower/envconfig
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/martinlindhe/base36 v1.1.1
+## explicit; go 1.16
+github.com/martinlindhe/base36
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil


### PR DESCRIPTION
# Changes

Fixes #482 

:broom: create unique common names for certs that are too long
* if the non-domain portion (name+namespace data) is long enough, replace it with a base36 version of the kcert UID.
* if that is still too long, then return an error
* update kcert status with details on why the cert isn't ready if CommonName is too long

🗑️ remove code made irrelevant after changes above
* remove broken use of ChildName function
* remove code that looks for matching domain in other certs. Don't need it if we have unique common names
* don't use domain template when creating a common name
* TODO: remove domain template config option



**Release Note**

```release-note

```
