### PR TITLE
Revert "Decrease coverage target to 75 from 80 (#432)"

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,9 +4,7 @@ coverage:
   status:
     project:
       default:
-        # TODO: increase target.
-        # https://github.com/knative-sandbox/net-certmanager/issues/431
-        target: 75
+        target: 80
         threshold: 1%
     patch:
       # Disable the coverage threshold of the patch, so that PRs are


### PR DESCRIPTION
This reverts commit 9b4a3de1023fbc0286c430ed30e15537eb554f32.

https://github.com/knative-sandbox/net-certmanager/pull/432 decreases the coverage but it seems the coverage is more than 80 recently.

Fix https://github.com/knative-sandbox/net-certmanager/issues/431