### PR TITLE
Add the ability to create `cluster-local` certificates by an internal cert-issuer

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,10 +39,18 @@ data:
     # These sample configuration options may be copied out of
     # this block and unindented to actually change the configuration.
 
-    # issuerRef is a reference to the issuer for this certificate.
+    # issuerRef is a reference to the issuer for cluster external certificates used for ingress.
     # IssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go
     # for more details about IssuerRef configuration.
     issuerRef: |
       kind: ClusterIssuer
       name: letsencrypt-issuer
+    
+    # internalIssuerRef is a reference to the issuer for cluster internal certificates.
+    # InternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go
+    # for more details about InternalIssuerRef configuration.
+    internalIssuerRef: |
+      kind: ClusterIssuer
+      name: knative-internal-encryption-issuer

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,6 +43,7 @@ data:
     # IssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go
     # for more details about IssuerRef configuration.
+    # If the issuerRef is not specified, the self-signed `knative-internal-encryption-ca` ClusterIssuer is used.
     issuerRef: |
       kind: ClusterIssuer
       name: letsencrypt-issuer
@@ -51,6 +52,7 @@ data:
     # InternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go
     # for more details about InternalIssuerRef configuration.
+    # If the internalIssuerRef is not specified, the self-signed `knative-internal-encryption-ca` ClusterIssuer is used.
     internalIssuerRef: |
       kind: ClusterIssuer
       name: knative-internal-encryption-issuer

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -48,11 +48,11 @@ data:
       kind: ClusterIssuer
       name: letsencrypt-issuer
 
-    # internalIssuerRef is a reference to the issuer for cluster internal certificates.
-    # InternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # clusterInternalIssuerRef is a reference to the issuer for cluster internal certificates used for ingress.
+    # ClusterInternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go
-    # for more details about InternalIssuerRef configuration.
-    # If the internalIssuerRef is not specified, the self-signed `knative-internal-encryption-ca` ClusterIssuer is used.
-    internalIssuerRef: |
+    # for more details about ClusterInternalIssuerRef configuration.
+    # If the clusterInternalIssuerRef is not specified, the self-signed `knative-internal-encryption-ca` ClusterIssuer is used.
+    clusterInternalIssuerRef: |
       kind: ClusterIssuer
       name: knative-internal-encryption-issuer

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,7 +46,7 @@ data:
     issuerRef: |
       kind: ClusterIssuer
       name: letsencrypt-issuer
-    
+
     # internalIssuerRef is a reference to the issuer for cluster internal certificates.
     # InternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
     # Please refer `IssuerRef` in https://github.com/cert-manager/cert-manager/tree/master/pkg/apis/certmanager/v1/types_certificate.go

--- a/config/knative-cluster-issuer.yaml
+++ b/config/knative-cluster-issuer.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cluster-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: knative-internal-encryption-issuer
+spec:
+  ca:
+    secretName: knative-internal-encryption-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: knative-internal-encryption-ca
+  namespace: cert-manager #  If you want to use it as a ClusterIssuer the secret must be in the cert-manager namespace.
+spec:
+  secretName: knative-internal-encryption-ca
+  commonName: knative.dev
+  usages:
+    - server auth
+  isCA: true
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -68,7 +68,7 @@ var (
 	notAfter          = &metav1.Time{
 		Time: time.Unix(123, 456),
 	}
-	internalIssuer = &cmv1.ClusterIssuer{
+	clusterInternalIssuer = &cmv1.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "knative-internal-encryption-issuer",
 		},
@@ -108,8 +108,8 @@ func TestNewController(t *testing.T) {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"issuerRef":         "kind: ClusterIssuer\nname: letsencrypt-issuer",
-			"internalIssuerRef": "kind: ClusterIssuer\nname: knative-internal-encryption-issuer",
+			"issuerRef":                "kind: ClusterIssuer\nname: letsencrypt-issuer",
+			"clusterInternalIssuerRef": "kind: ClusterIssuer\nname: knative-internal-encryption-issuer",
 		},
 	})
 
@@ -485,11 +485,11 @@ func TestReconcile(t *testing.T) {
 				}),
 		}},
 	}, {
-		Name: "create internalIssuer CM certificate matching Knative Certificate, with retry",
+		Name: "create clusterInternalIssuer CM certificate matching Knative Certificate, with retry",
 		Key:  "foo/knCert",
 		Objects: []runtime.Object{
 			withClusterLocalVisibility(knCert("knCert", "foo")),
-			internalIssuer,
+			clusterInternalIssuer,
 		},
 		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
@@ -722,7 +722,7 @@ func certmanagerConfig() *config.CertManagerConfig {
 			Kind: "ClusterIssuer",
 			Name: "Letsencrypt-issuer",
 		},
-		InternalIssuerRef: &cmmeta.ObjectReference{
+		ClusterInternalIssuerRef: &cmmeta.ObjectReference{
 			Kind: "ClusterIssuer",
 			Name: "knative-internal-encryption-issuer",
 		},

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -324,7 +324,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantEvents: []string{
-			"Warning InternalError error creating Certmanager Certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
+			"Warning InternalError error creating cert-manager certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: knCertDomainTooLong("knCert", "foo",
@@ -337,7 +337,7 @@ func TestReconcile(t *testing.T) {
 								Status:   corev1.ConditionFalse,
 								Severity: apis.ConditionSeverityError,
 								Reason:   "CommonName Too Long",
-								Message:  "error creating Certmanager Certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
+								Message:  "error creating cert-manager certificate: cannot create valid length CommonName: (hello.ns.reallyreallyreallyreallyreallyreallyreallylong.domainname) still longer than 63 characters, cannot shorten",
 							},
 						},
 					},

--- a/pkg/reconciler/certificate/config/cert_manager.go
+++ b/pkg/reconciler/certificate/config/cert_manager.go
@@ -32,6 +32,12 @@ const (
 	CertManagerConfigName = "config-certmanager"
 )
 
+// has to match the values in config/knative-cluster-issuer.yaml
+var knativeInternalClusterIssuerRef = &cmeta.ObjectReference{
+	Kind: "ClusterIssuer",
+	Name: "knative-internal-encryption-ca",
+}
+
 // CertManagerConfig contains Cert-Manager related configuration defined in the
 // `config-certmanager` config map.
 type CertManagerConfig struct {
@@ -41,17 +47,19 @@ type CertManagerConfig struct {
 
 // NewCertManagerConfigFromConfigMap creates an CertManagerConfig from the supplied ConfigMap
 func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManagerConfig, error) {
-	config := &CertManagerConfig{}
+	// Use Knative self-signed ClusterIssuer as default
+	config := &CertManagerConfig{
+		IssuerRef:         knativeInternalClusterIssuerRef,
+		InternalIssuerRef: knativeInternalClusterIssuerRef,
+	}
 
 	if v, ok := configMap.Data[issuerRefKey]; ok {
-		config.IssuerRef = &cmeta.ObjectReference{}
 		if err := yaml.Unmarshal([]byte(v), config.IssuerRef); err != nil {
 			return nil, err
 		}
 	}
 
 	if v, ok := configMap.Data[internalIssuerRefKey]; ok {
-		config.InternalIssuerRef = &cmeta.ObjectReference{}
 		if err := yaml.Unmarshal([]byte(v), config.InternalIssuerRef); err != nil {
 			return nil, err
 		}

--- a/pkg/reconciler/certificate/config/cert_manager.go
+++ b/pkg/reconciler/certificate/config/cert_manager.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	issuerRefKey = "issuerRef"
+	issuerRefKey         = "issuerRef"
+	internalIssuerRefKey = "internalIssuerRef"
 
 	// CertManagerConfigName is the name of the configmap containing all
 	// configuration related to Cert-Manager.
@@ -34,20 +35,24 @@ const (
 // CertManagerConfig contains Cert-Manager related configuration defined in the
 // `config-certmanager` config map.
 type CertManagerConfig struct {
-	IssuerRef *cmeta.ObjectReference
+	IssuerRef         *cmeta.ObjectReference
+	InternalIssuerRef *cmeta.ObjectReference
 }
 
 // NewCertManagerConfigFromConfigMap creates an CertManagerConfig from the supplied ConfigMap
 func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManagerConfig, error) {
-	// TODO(zhiminx): do we need to provide the default values here?
-	// TODO: validation check.
-
-	config := &CertManagerConfig{
-		IssuerRef: &cmeta.ObjectReference{},
-	}
+	config := &CertManagerConfig{}
 
 	if v, ok := configMap.Data[issuerRefKey]; ok {
+		config.IssuerRef = &cmeta.ObjectReference{}
 		if err := yaml.Unmarshal([]byte(v), config.IssuerRef); err != nil {
+			return nil, err
+		}
+	}
+
+	if v, ok := configMap.Data[internalIssuerRefKey]; ok {
+		config.InternalIssuerRef = &cmeta.ObjectReference{}
+		if err := yaml.Unmarshal([]byte(v), config.InternalIssuerRef); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/reconciler/certificate/config/cert_manager.go
+++ b/pkg/reconciler/certificate/config/cert_manager.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	issuerRefKey         = "issuerRef"
-	internalIssuerRefKey = "internalIssuerRef"
+	issuerRefKey                = "issuerRef"
+	clusterInternalIssuerRefKey = "clusterInternalIssuerRef"
 
 	// CertManagerConfigName is the name of the configmap containing all
 	// configuration related to Cert-Manager.
@@ -33,7 +33,7 @@ const (
 )
 
 // has to match the values in config/knative-cluster-issuer.yaml
-var knativeInternalClusterIssuerRef = &cmeta.ObjectReference{
+var knativeInternalIssuer = &cmeta.ObjectReference{
 	Kind: "ClusterIssuer",
 	Name: "knative-internal-encryption-ca",
 }
@@ -41,16 +41,16 @@ var knativeInternalClusterIssuerRef = &cmeta.ObjectReference{
 // CertManagerConfig contains Cert-Manager related configuration defined in the
 // `config-certmanager` config map.
 type CertManagerConfig struct {
-	IssuerRef         *cmeta.ObjectReference
-	InternalIssuerRef *cmeta.ObjectReference
+	IssuerRef                *cmeta.ObjectReference
+	ClusterInternalIssuerRef *cmeta.ObjectReference
 }
 
 // NewCertManagerConfigFromConfigMap creates an CertManagerConfig from the supplied ConfigMap
 func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManagerConfig, error) {
 	// Use Knative self-signed ClusterIssuer as default
 	config := &CertManagerConfig{
-		IssuerRef:         knativeInternalClusterIssuerRef,
-		InternalIssuerRef: knativeInternalClusterIssuerRef,
+		IssuerRef:                knativeInternalIssuer,
+		ClusterInternalIssuerRef: knativeInternalIssuer,
 	}
 
 	if v, ok := configMap.Data[issuerRefKey]; ok {
@@ -59,8 +59,8 @@ func NewCertManagerConfigFromConfigMap(configMap *corev1.ConfigMap) (*CertManage
 		}
 	}
 
-	if v, ok := configMap.Data[internalIssuerRefKey]; ok {
-		if err := yaml.Unmarshal([]byte(v), config.InternalIssuerRef); err != nil {
+	if v, ok := configMap.Data[clusterInternalIssuerRefKey]; ok {
+		if err := yaml.Unmarshal([]byte(v), config.ClusterInternalIssuerRef); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -56,7 +56,8 @@ func TestIssuerRef(t *testing.T) {
 				Name:      CertManagerConfigName,
 			},
 			Data: map[string]string{
-				issuerRefKey: "wrong format",
+				issuerRefKey:         "wrong format",
+				internalIssuerRefKey: "wrong format",
 			},
 		},
 	}, {

--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -68,6 +68,7 @@ func TestIssuerRef(t *testing.T) {
 				Name: "letsencrypt-issuer",
 				Kind: "ClusterIssuer",
 			},
+			InternalIssuerRef: knativeInternalClusterIssuerRef,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -82,6 +83,7 @@ func TestIssuerRef(t *testing.T) {
 		name:    "valid internalIssuerRef",
 		wantErr: false,
 		wantConfig: &CertManagerConfig{
+			IssuerRef: knativeInternalClusterIssuerRef,
 			InternalIssuerRef: &cmmeta.ObjectReference{
 				Name: "knative-internal-encryption-issuer",
 				Kind: "ClusterIssuer",

--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -77,6 +77,24 @@ func TestIssuerRef(t *testing.T) {
 				issuerRefKey: "kind: ClusterIssuer\nname: letsencrypt-issuer",
 			},
 		},
+	}, {
+		name:    "valid internalIssuerRef",
+		wantErr: false,
+		wantConfig: &CertManagerConfig{
+			InternalIssuerRef: &cmmeta.ObjectReference{
+				Name: "knative-internal-encryption-issuer",
+				Kind: "ClusterIssuer",
+			},
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      CertManagerConfigName,
+			},
+			Data: map[string]string{
+				internalIssuerRefKey: "kind: ClusterIssuer\nname: knative-internal-encryption-issuer",
+			},
+		},
 	}}
 
 	for _, tt := range isserRefCases {

--- a/pkg/reconciler/certificate/config/cert_manager_test.go
+++ b/pkg/reconciler/certificate/config/cert_manager_test.go
@@ -56,8 +56,8 @@ func TestIssuerRef(t *testing.T) {
 				Name:      CertManagerConfigName,
 			},
 			Data: map[string]string{
-				issuerRefKey:         "wrong format",
-				internalIssuerRefKey: "wrong format",
+				issuerRefKey:                "wrong format",
+				clusterInternalIssuerRefKey: "wrong format",
 			},
 		},
 	}, {
@@ -68,7 +68,7 @@ func TestIssuerRef(t *testing.T) {
 				Name: "letsencrypt-issuer",
 				Kind: "ClusterIssuer",
 			},
-			InternalIssuerRef: knativeInternalClusterIssuerRef,
+			ClusterInternalIssuerRef: knativeInternalIssuer,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -80,11 +80,11 @@ func TestIssuerRef(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "valid internalIssuerRef",
+		name:    "valid clusterInternalIssuerRef",
 		wantErr: false,
 		wantConfig: &CertManagerConfig{
-			IssuerRef: knativeInternalClusterIssuerRef,
-			InternalIssuerRef: &cmmeta.ObjectReference{
+			IssuerRef: knativeInternalIssuer,
+			ClusterInternalIssuerRef: &cmmeta.ObjectReference{
 				Name: "knative-internal-encryption-issuer",
 				Kind: "ClusterIssuer",
 			},
@@ -95,7 +95,7 @@ func TestIssuerRef(t *testing.T) {
 				Name:      CertManagerConfigName,
 			},
 			Data: map[string]string{
-				internalIssuerRefKey: "kind: ClusterIssuer\nname: knative-internal-encryption-issuer",
+				clusterInternalIssuerRefKey: "kind: ClusterIssuer\nname: knative-internal-encryption-issuer",
 			},
 		},
 	}}

--- a/pkg/reconciler/certificate/config/store_test.go
+++ b/pkg/reconciler/certificate/config/store_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	cmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/google/go-cmp/cmp"
 	configmaptesting "knative.dev/pkg/configmap/testing"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -43,9 +44,12 @@ func TestStoreImmutableConfig(t *testing.T) {
 	store.OnConfigChanged(configmaptesting.ConfigMapFromTestFile(t, CertManagerConfigName))
 	config := store.Load()
 
-	config.CertManager.IssuerRef.Kind = "newKind"
+	config.CertManager.IssuerRef = &cmeta.ObjectReference{
+		Kind: "newKind",
+	}
+
 	newConfig := store.Load()
-	if newConfig.CertManager.IssuerRef.Kind == "newKind" {
+	if newConfig.CertManager.IssuerRef != nil && newConfig.CertManager.IssuerRef.Kind == "newKind" {
 		t.Error("CertManager config is not immutable")
 	}
 }

--- a/pkg/reconciler/certificate/config/store_test.go
+++ b/pkg/reconciler/certificate/config/store_test.go
@@ -48,7 +48,7 @@ func TestStoreImmutableConfig(t *testing.T) {
 		Kind: "newKind",
 	}
 
-	config.CertManager.InternalIssuerRef = &cmeta.ObjectReference{
+	config.CertManager.ClusterInternalIssuerRef = &cmeta.ObjectReference{
 		Kind: "newKind",
 	}
 
@@ -56,7 +56,7 @@ func TestStoreImmutableConfig(t *testing.T) {
 	if newConfig.CertManager.IssuerRef != nil && newConfig.CertManager.IssuerRef.Kind == "newKind" {
 		t.Error("CertManager config is not immutable")
 	}
-	if newConfig.CertManager.InternalIssuerRef != nil && newConfig.CertManager.InternalIssuerRef.Kind == "newKind" {
+	if newConfig.CertManager.ClusterInternalIssuerRef != nil && newConfig.CertManager.ClusterInternalIssuerRef.Kind == "newKind" {
 		t.Error("CertManager config is not immutable")
 	}
 }

--- a/pkg/reconciler/certificate/config/store_test.go
+++ b/pkg/reconciler/certificate/config/store_test.go
@@ -48,8 +48,15 @@ func TestStoreImmutableConfig(t *testing.T) {
 		Kind: "newKind",
 	}
 
+	config.CertManager.InternalIssuerRef = &cmeta.ObjectReference{
+		Kind: "newKind",
+	}
+
 	newConfig := store.Load()
 	if newConfig.CertManager.IssuerRef != nil && newConfig.CertManager.IssuerRef.Kind == "newKind" {
+		t.Error("CertManager config is not immutable")
+	}
+	if newConfig.CertManager.InternalIssuerRef != nil && newConfig.CertManager.InternalIssuerRef.Kind == "newKind" {
 		t.Error("CertManager config is not immutable")
 	}
 }

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate.go
@@ -140,15 +140,15 @@ func MakeCertManagerCertificate(cmConfig *config.CertManagerConfig, knCert *v1al
 
 	var issuerRef cmeta.ObjectReference
 	if knCert.Labels[networking.VisibilityLabelKey] == VisibilityClusterLocal {
-		if cmConfig.InternalIssuerRef == nil {
+		if cmConfig.ClusterInternalIssuerRef == nil {
 			return nil, &apis.Condition{
 				Type:    IssuerNotSetCondition,
 				Status:  corev1.ConditionFalse,
-				Reason:  "internalIssuerRef not set",
-				Message: "error creating cert-manager certificate: internalIssuerRef was not set in config-certmanager",
+				Reason:  "clusterInternalIssuerRef not set",
+				Message: "error creating cert-manager certificate: clusterInternalIssuerRef was not set in config-certmanager",
 			}
 		}
-		issuerRef = *cmConfig.InternalIssuerRef
+		issuerRef = *cmConfig.ClusterInternalIssuerRef
 	} else {
 		if cmConfig.IssuerRef == nil {
 			return nil, &apis.Condition{

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -186,7 +186,7 @@ func TestMakeCertManagerCertificateLongCommonName(t *testing.T) {
 }
 
 func TestMakeCertManagerCertificateDomainMappingIsTooLong(t *testing.T) {
-	wantError := fmt.Errorf("error creating Certmanager Certificate: DomainMapping name (this.is.aaaaaaaaaaaaaaa.reallyreallyreallyreallyreallylong.domainmapping) longer than 63 characters")
+	wantError := fmt.Errorf("error creating cert-manager certificate: DomainMapping name (this.is.aaaaaaaaaaaaaaa.reallyreallyreallyreallyreallylong.domainmapping) longer than 63 characters")
 	cert, gotError := MakeCertManagerCertificate(cmConfig, &v1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cert-from-domain-mapping",
@@ -217,7 +217,7 @@ func TestMakeCertManagerCertificateDomainMappingIsTooLong(t *testing.T) {
 }
 
 func TestMakeCertManagerCertificateDomainIsTooLong(t *testing.T) {
-	wantError := fmt.Errorf("error creating Certmanager Certificate: cannot create valid length CommonName: (host1.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com) still longer than 63 characters, cannot shorten")
+	wantError := fmt.Errorf("error creating cert-manager certificate: cannot create valid length CommonName: (host1.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com) still longer than 63 characters, cannot shorten")
 	cert, gotError := MakeCertManagerCertificate(cmConfig, certWithLongDomain)
 
 	if cert != nil {

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -291,6 +291,57 @@ func TestMakeCertManagerCertificateDomainIsTooLong(t *testing.T) {
 	}
 }
 
+func TestMakeCertManagerCertificateInvalidUID(t *testing.T) {
+	wantError := fmt.Errorf("error creating cert-manager certificate: failed to parse UID (wrong) on KCert (test-cert): invalid UUID length: 5")
+
+	wrongUIDCert := certWithLongHost.DeepCopy()
+	wrongUIDCert.UID = "wrong"
+
+	cert, gotError := MakeCertManagerCertificate(cmConfig, wrongUIDCert)
+
+	if cert != nil {
+		t.Errorf("Expected no cert, got: %s", cmp.Diff(nil, cert))
+	}
+
+	if diff := cmp.Diff(wantError.Error(), gotError.Message); diff != "" {
+		t.Errorf("MakeCertManagerCertificate (-want, +got) = %s", diff)
+	}
+}
+
+func TestMakeCertManagerCertificateIssuerNotSet(t *testing.T) {
+	wantError := fmt.Errorf("error creating cert-manager certificate: issuerRef was not set in config-certmanager")
+
+	cmConfigNoIssuer := cmConfig.DeepCopy()
+	cmConfigNoIssuer.IssuerRef = nil
+
+	cert, gotError := MakeCertManagerCertificate(cmConfigNoIssuer, cert)
+
+	if cert != nil {
+		t.Errorf("Expected no cert, got: %s", cmp.Diff(nil, cert))
+	}
+
+	if diff := cmp.Diff(wantError.Error(), gotError.Message); diff != "" {
+		t.Errorf("MakeCertManagerCertificate (-want, +got) = %s", diff)
+	}
+}
+
+func TestMakeCertManagerCertificateInternalIssuerNotSet(t *testing.T) {
+	wantError := fmt.Errorf("error creating cert-manager certificate: internalIssuerRef was not set in config-certmanager")
+
+	cmConfigNoIssuer := cmConfig.DeepCopy()
+	cmConfigNoIssuer.InternalIssuerRef = nil
+
+	cert, gotError := MakeCertManagerCertificate(cmConfigNoIssuer, internalCert)
+
+	if cert != nil {
+		t.Errorf("Expected no cert, got: %s", cmp.Diff(nil, cert))
+	}
+
+	if diff := cmp.Diff(wantError.Error(), gotError.Message); diff != "" {
+		t.Errorf("MakeCertManagerCertificate (-want, +got) = %s", diff)
+	}
+}
+
 func TestGetReadyCondition(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
+++ b/pkg/reconciler/certificate/resources/cert_manager_certificate_test.go
@@ -131,7 +131,7 @@ var (
 			Kind: "ClusterIssuer",
 			Name: "Letsencrypt-issuer",
 		},
-		InternalIssuerRef: &cmmeta.ObjectReference{
+		ClusterInternalIssuerRef: &cmmeta.ObjectReference{
 			Kind: "ClusterIssuer",
 			Name: "knative-internal-encryption-issuer",
 		},
@@ -326,10 +326,10 @@ func TestMakeCertManagerCertificateIssuerNotSet(t *testing.T) {
 }
 
 func TestMakeCertManagerCertificateInternalIssuerNotSet(t *testing.T) {
-	wantError := fmt.Errorf("error creating cert-manager certificate: internalIssuerRef was not set in config-certmanager")
+	wantError := fmt.Errorf("error creating cert-manager certificate: clusterInternalIssuerRef was not set in config-certmanager")
 
 	cmConfigNoIssuer := cmConfig.DeepCopy()
-	cmConfigNoIssuer.InternalIssuerRef = nil
+	cmConfigNoIssuer.ClusterInternalIssuerRef = nil
 
 	cert, gotError := MakeCertManagerCertificate(cmConfigNoIssuer, internalCert)
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Knative Authors
 #

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The Knative Authors
 #


### PR DESCRIPTION
# Context
* This feature is a prerequisite to enable https://github.com/knative/serving/issues/13472.
* Belongs to
  * [Knative Serving Internal Data Path TLS and mTLS](https://docs.google.com/document/d/1XE7UzgQlVVtAb7ULSqOyKCaIHtm8zMF35ainp1JmwyY/edit?resourcekey=0-e1MXRxQaalq-EHW46ZCCWg#heading=h.n8a530nnrb)
  * [Findings Document](https://docs.google.com/document/d/1YdcdBVg_zpT4WSNRsWlihut5JuLddOTIggFvLni3A28/edit#heading=h.n8a530nnrb)

> 📝 Please note that this is only a partial view of the hole feature. Please refer to https://github.com/ReToCode/knative-encryption/blob/main/4-final-setup/HOW_DOES_IT_WORK.md for the bigger picture.

![Visualization](https://raw.githubusercontent.com/ReToCode/diagrams/main/knative-encryption/internal-encryption-overview.drawio.svg)

# Changes
- 🎁 Add the ability to create cluster-local certificates by an internal cert-issuer
- 🎁 Introduces an additional configuration flag to specify an issuer reference for cluster-local certificates

/kind enhancement

**Release Note**

```release-note
`net-certmanager` is now able to generate cluster-local certificates using the new issuer reference `clusterInternalIssuerRef` in `config-certmanager`.
If no `issuerRef` or `clusterInternalIssuerRef` is configured in `config-certmanager` a new internal self-signed `ClusterIssuer` is used. 
```

**Docs**

Will be done for the completed feature (when serving and net-* changes are also done).
